### PR TITLE
node connections via id

### DIFF
--- a/examples/nested_graphs.py
+++ b/examples/nested_graphs.py
@@ -38,12 +38,13 @@ if __name__ == "__main__":
     # o file<>         |     +--->o file<>                     |     +--->o file<>         |
     # |           file o-----+    |                       file o-----+    |           file o
     # +----------------+          +----------------------------+          +----------------+
-    udpate_db_from_file = Graph(name="udpate_db_from_file")
-    find_file = MyNode(name="Find File", graph=udpate_db_from_file)
+    update_db_from_file = Graph(name="udpate_db_from_file")
+    #find_file = MyNode(name="Find File", graph=udpate_db_from_file)
+    find_file = MyNode(name="Change Lineendings", graph=update_db_from_file)
     values_from_file = MyNode(
-        name="Read Values from File", graph=udpate_db_from_file
+        name="Read Values from File", graph=update_db_from_file
     )
-    update_db = MyNode(name="Update DB", graph=udpate_db_from_file)
+    update_db = MyNode(name="Update DB", graph=update_db_from_file)
     find_file.outputs["file"].connect(values_from_file.inputs["file"])
     values_from_file.outputs["file"].connect(update_db.inputs["file"])
 
@@ -61,9 +62,9 @@ if __name__ == "__main__":
     # Now the update_db graph can connect nodes to the fix_file graph
     find_file.outputs["file"].connect(fix_file.inputs["file_to_clean"])
     fix_file.outputs["clean_file"].connect(
-        udpate_db_from_file["Read Values from File"].inputs["file"]
+        update_db_from_file["Read Values from File"].inputs["file"]
     )
-
+    print(fix_file)
     # Display the graph
     app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(

--- a/examples/nested_graphs.py
+++ b/examples/nested_graphs.py
@@ -38,9 +38,9 @@ if __name__ == "__main__":
     # o file<>         |     +--->o file<>                     |     +--->o file<>         |
     # |           file o-----+    |                       file o-----+    |           file o
     # +----------------+          +----------------------------+          +----------------+
-    update_db_from_file = Graph(name="udpate_db_from_file")
-    #find_file = MyNode(name="Find File", graph=udpate_db_from_file)
-    find_file = MyNode(name="Change Lineendings", graph=update_db_from_file)
+    update_db_from_file = Graph(name="update_db_from_file")
+    find_file = MyNode(name="Find File", graph=update_db_from_file)
+
     values_from_file = MyNode(
         name="Read Values from File", graph=update_db_from_file
     )
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     fix_file.outputs["clean_file"].connect(
         update_db_from_file["Read Values from File"].inputs["file"]
     )
-    print(fix_file)
+
     # Display the graph
     app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(

--- a/examples/nested_graphs.py
+++ b/examples/nested_graphs.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     )
 
     window = QtWidgets.QWidget()
-    window.setWindowTitle("Flowpipe-Editor Nestd Graphs Example")
+    window.setWindowTitle("Flowpipe-Editor Nested Graphs Example")
     window.resize(1100, 800)
 
     flowpipe_editor_widget = FlowpipeEditorWidget(parent=window)

--- a/flowpipe_editor/flowpipe_editor_widget.py
+++ b/flowpipe_editor/flowpipe_editor_widget.py
@@ -166,11 +166,13 @@ class FlowpipeEditorWidget(QtWidgets.QWidget):
         self.clear()
         self.flowpipe_graph = graph
         x_pos = 0
+        nodes_dict = {}
         for row in graph.evaluation_matrix:
             y_pos = 0
             x_diff = 250
             for fp_node in row:
-                self._add_node(fp_node, QtCore.QPoint(int(x_pos), int(y_pos)))
+                qt_node =self._add_node(fp_node, QtCore.QPoint(int(x_pos), int(y_pos)))
+                nodes_dict[fp_node.identifier] = qt_node
                 y_pos += 150
             x_pos += x_diff
         for fp_node in graph.all_nodes:
@@ -179,11 +181,9 @@ class FlowpipeEditorWidget(QtWidgets.QWidget):
                     in_index = list(
                         connection.node.all_inputs().values()
                     ).index(connection)
-                    self.graph.get_node_by_name(fp_node.name).set_output(
+                    nodes_dict[fp_node.identifier].set_output(
                         i,
-                        self.graph.get_node_by_name(
-                            connection.node.name
-                        ).input(in_index),
+                        nodes_dict[connection.node.identifier].input(in_index),
                     )
 
         nodes = self.graph.all_nodes()

--- a/flowpipe_editor/widgets/properties_bin/attribute_widgets.py
+++ b/flowpipe_editor/widgets/properties_bin/attribute_widgets.py
@@ -17,7 +17,8 @@ class PopeUpLineEdit(QtWidgets.QLineEdit):
         super().__init__(parent)
         self.label = label
 
-    def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent):
+    def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent):  # pylint: disable=invalid-name
+        """Open a popup dialog to edit the line edit contents on double-click."""
         # Open popup dialog on double-click
         dialog = PopupDialog(self.label, self.text(), self)
         dialog.exec_()


### PR DESCRIPTION
Fixes node connection if nodes have the same name.

NodeGraphQt doesn't allow nodes with the same name, so the ui will append 1 etc. to the node name

Closes #13